### PR TITLE
Update PHPCompatibility testVersion from '5.6-' to '7.0-'

### DIFF
--- a/src/SkyVerge_PHP_Base/ruleset.xml
+++ b/src/SkyVerge_PHP_Base/ruleset.xml
@@ -76,6 +76,6 @@
     <!-- Run against the PHPCompatibilityWP ruleset -->
     <rule ref="PHPCompatibilityWP" />
 
-    <!-- Check for cross-version support for PHP 5.6 and higher. -->
-    <config name="testVersion" value="5.6-"/>
+    <!-- Check for cross-version support for PHP 7.0 and higher. -->
+    <config name="testVersion" value="7.0-"/>
 </ruleset>


### PR DESCRIPTION
# Summary

This PR updates the PHPCompatibilityWP rules in SkyVerge PHP Coding Standard to automatically check that our changes are compatible with PHP 7.0 or newer.

### Story: [CH 74881](https://app.clubhouse.io/skyverge/story/74881)

## QA

- [ ] Code review